### PR TITLE
Naming fix, payment-order relation fix, squash migrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,4 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+OMGVA PoS/appsettings.json

--- a/OMGVA PoS/Data layer/Context/OMGVADbContext.cs
+++ b/OMGVA PoS/Data layer/Context/OMGVADbContext.cs
@@ -10,8 +10,8 @@ namespace OMGVA_PoS.Data_layer.Context
         public DbSet<Customer> Customers { get; set; }
         public DbSet<Discount> Discounts { get; set; }
         public DbSet<EmployeeSchedule> EmployeeSchedules { get; set; }
-        public DbSet<GiftCard> GiftCards { get; set; }
-        public DbSet<GiftCardPayment> GiftCardPayments { get; set; }
+        public DbSet<Giftcard> Giftcards { get; set; }
+        public DbSet<GiftcardPayment> GiftcardPayments { get; set; }
         public DbSet<Item> Items { get; set; }
         public DbSet<ItemVariation> ItemVariations { get; set; }
         public DbSet<Order> Orders { get; set; }

--- a/OMGVA PoS/Data layer/Migrations/20241208205141_InitialMigration.Designer.cs
+++ b/OMGVA PoS/Data layer/Migrations/20241208205141_InitialMigration.Designer.cs
@@ -9,11 +9,11 @@ using OMGVA_PoS.Data_layer.Context;
 
 #nullable disable
 
-namespace OMGVA_PoS.Migrations
+namespace OMGVA_PoS.Datalayer.Migrations
 {
     [DbContext(typeof(OMGVADbContext))]
-    [Migration("20241119114334_InitialCreate")]
-    partial class InitialCreate
+    [Migration("20241208205141_InitialMigration")]
+    partial class InitialMigration
     {
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
@@ -130,7 +130,7 @@ namespace OMGVA_PoS.Migrations
                     b.ToTable("EmployeeSchedules");
                 });
 
-            modelBuilder.Entity("OMGVA_PoS.Data_layer.Models.GiftCard", b =>
+            modelBuilder.Entity("OMGVA_PoS.Data_layer.Models.Giftcard", b =>
                 {
                     b.Property<long>("Id")
                         .ValueGeneratedOnAdd()
@@ -146,10 +146,10 @@ namespace OMGVA_PoS.Migrations
 
                     b.HasKey("Id");
 
-                    b.ToTable("GiftCards");
+                    b.ToTable("Giftcards");
                 });
 
-            modelBuilder.Entity("OMGVA_PoS.Data_layer.Models.GiftCardPayment", b =>
+            modelBuilder.Entity("OMGVA_PoS.Data_layer.Models.GiftcardPayment", b =>
                 {
                     b.Property<long>("Id")
                         .ValueGeneratedOnAdd()
@@ -160,14 +160,14 @@ namespace OMGVA_PoS.Migrations
                     b.Property<decimal>("AmountUsed")
                         .HasColumnType("decimal(18,2)");
 
-                    b.Property<long>("GiftCardId")
+                    b.Property<long>("GiftcardId")
                         .HasColumnType("bigint");
 
                     b.HasKey("Id");
 
-                    b.HasIndex("GiftCardId");
+                    b.HasIndex("GiftcardId");
 
-                    b.ToTable("GiftCardPayments");
+                    b.ToTable("GiftcardPayments");
                 });
 
             modelBuilder.Entity("OMGVA_PoS.Data_layer.Models.Item", b =>
@@ -267,6 +267,10 @@ namespace OMGVA_PoS.Migrations
                     b.Property<long?>("DiscountId")
                         .HasColumnType("bigint");
 
+                    b.Property<string>("PaymentId")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(450)");
+
                     b.Property<string>("RefundReason")
                         .IsRequired()
                         .HasColumnType("nvarchar(max)");
@@ -283,6 +287,9 @@ namespace OMGVA_PoS.Migrations
                     b.HasKey("Id");
 
                     b.HasIndex("DiscountId");
+
+                    b.HasIndex("PaymentId")
+                        .IsUnique();
 
                     b.HasIndex("UserId");
 
@@ -343,11 +350,8 @@ namespace OMGVA_PoS.Migrations
 
             modelBuilder.Entity("OMGVA_PoS.Data_layer.Models.Payment", b =>
                 {
-                    b.Property<long>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("bigint");
-
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
+                    b.Property<string>("Id")
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<long>("CustomerId")
                         .HasColumnType("bigint");
@@ -358,16 +362,11 @@ namespace OMGVA_PoS.Migrations
                     b.Property<int>("Method")
                         .HasColumnType("int");
 
-                    b.Property<long>("OrderId")
-                        .HasColumnType("bigint");
-
                     b.HasKey("Id");
 
                     b.HasIndex("CustomerId");
 
                     b.HasIndex("GiftCardPaymentId");
-
-                    b.HasIndex("OrderId");
 
                     b.ToTable("Payments");
                 });
@@ -516,15 +515,15 @@ namespace OMGVA_PoS.Migrations
                     b.Navigation("User");
                 });
 
-            modelBuilder.Entity("OMGVA_PoS.Data_layer.Models.GiftCardPayment", b =>
+            modelBuilder.Entity("OMGVA_PoS.Data_layer.Models.GiftcardPayment", b =>
                 {
-                    b.HasOne("OMGVA_PoS.Data_layer.Models.GiftCard", "GiftCard")
-                        .WithMany("GiftCardPayments")
-                        .HasForeignKey("GiftCardId")
+                    b.HasOne("OMGVA_PoS.Data_layer.Models.Giftcard", "Giftcard")
+                        .WithMany("GiftcardPayments")
+                        .HasForeignKey("GiftcardId")
                         .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
-                    b.Navigation("GiftCard");
+                    b.Navigation("Giftcard");
                 });
 
             modelBuilder.Entity("OMGVA_PoS.Data_layer.Models.Item", b =>
@@ -563,6 +562,12 @@ namespace OMGVA_PoS.Migrations
                         .HasForeignKey("DiscountId")
                         .OnDelete(DeleteBehavior.Restrict);
 
+                    b.HasOne("OMGVA_PoS.Data_layer.Models.Payment", "Payment")
+                        .WithOne("Order")
+                        .HasForeignKey("OMGVA_PoS.Data_layer.Models.Order", "PaymentId")
+                        .OnDelete(DeleteBehavior.Restrict)
+                        .IsRequired();
+
                     b.HasOne("OMGVA_PoS.Data_layer.Models.User", "User")
                         .WithMany("Orders")
                         .HasForeignKey("UserId")
@@ -570,6 +575,8 @@ namespace OMGVA_PoS.Migrations
                         .IsRequired();
 
                     b.Navigation("Discount");
+
+                    b.Navigation("Payment");
 
                     b.Navigation("User");
                 });
@@ -619,22 +626,14 @@ namespace OMGVA_PoS.Migrations
                         .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
-                    b.HasOne("OMGVA_PoS.Data_layer.Models.GiftCardPayment", "GiftCardPayment")
+                    b.HasOne("OMGVA_PoS.Data_layer.Models.GiftcardPayment", "GiftcardPayment")
                         .WithMany()
                         .HasForeignKey("GiftCardPaymentId")
                         .OnDelete(DeleteBehavior.Restrict);
 
-                    b.HasOne("OMGVA_PoS.Data_layer.Models.Order", "Order")
-                        .WithMany("Payments")
-                        .HasForeignKey("OrderId")
-                        .OnDelete(DeleteBehavior.Restrict)
-                        .IsRequired();
-
                     b.Navigation("Customer");
 
-                    b.Navigation("GiftCardPayment");
-
-                    b.Navigation("Order");
+                    b.Navigation("GiftcardPayment");
                 });
 
             modelBuilder.Entity("OMGVA_PoS.Data_layer.Models.Reservation", b =>
@@ -721,9 +720,9 @@ namespace OMGVA_PoS.Migrations
                     b.Navigation("Orders");
                 });
 
-            modelBuilder.Entity("OMGVA_PoS.Data_layer.Models.GiftCard", b =>
+            modelBuilder.Entity("OMGVA_PoS.Data_layer.Models.Giftcard", b =>
                 {
-                    b.Navigation("GiftCardPayments");
+                    b.Navigation("GiftcardPayments");
                 });
 
             modelBuilder.Entity("OMGVA_PoS.Data_layer.Models.Item", b =>
@@ -741,13 +740,17 @@ namespace OMGVA_PoS.Migrations
             modelBuilder.Entity("OMGVA_PoS.Data_layer.Models.Order", b =>
                 {
                     b.Navigation("OrderItems");
-
-                    b.Navigation("Payments");
                 });
 
             modelBuilder.Entity("OMGVA_PoS.Data_layer.Models.OrderItem", b =>
                 {
                     b.Navigation("OrderItemVariations");
+                });
+
+            modelBuilder.Entity("OMGVA_PoS.Data_layer.Models.Payment", b =>
+                {
+                    b.Navigation("Order")
+                        .IsRequired();
                 });
 
             modelBuilder.Entity("OMGVA_PoS.Data_layer.Models.Tax", b =>

--- a/OMGVA PoS/Data layer/Migrations/20241208205141_InitialMigration.cs
+++ b/OMGVA PoS/Data layer/Migrations/20241208205141_InitialMigration.cs
@@ -3,10 +3,10 @@ using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 
-namespace OMGVA_PoS.Migrations
+namespace OMGVA_PoS.Datalayer.Migrations
 {
     /// <inheritdoc />
-    public partial class InitialCreate : Migration
+    public partial class InitialMigration : Migration
     {
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
@@ -58,7 +58,7 @@ namespace OMGVA_PoS.Migrations
                 });
 
             migrationBuilder.CreateTable(
-                name: "GiftCards",
+                name: "Giftcards",
                 columns: table => new
                 {
                     Id = table.Column<long>(type: "bigint", nullable: false)
@@ -68,7 +68,7 @@ namespace OMGVA_PoS.Migrations
                 },
                 constraints: table =>
                 {
-                    table.PrimaryKey("PK_GiftCards", x => x.Id);
+                    table.PrimaryKey("PK_Giftcards", x => x.Id);
                 });
 
             migrationBuilder.CreateTable(
@@ -164,21 +164,21 @@ namespace OMGVA_PoS.Migrations
                 });
 
             migrationBuilder.CreateTable(
-                name: "GiftCardPayments",
+                name: "GiftcardPayments",
                 columns: table => new
                 {
                     Id = table.Column<long>(type: "bigint", nullable: false)
                         .Annotation("SqlServer:Identity", "1, 1"),
-                    GiftCardId = table.Column<long>(type: "bigint", nullable: false),
+                    GiftcardId = table.Column<long>(type: "bigint", nullable: false),
                     AmountUsed = table.Column<decimal>(type: "decimal(18,2)", nullable: false)
                 },
                 constraints: table =>
                 {
-                    table.PrimaryKey("PK_GiftCardPayments", x => x.Id);
+                    table.PrimaryKey("PK_GiftcardPayments", x => x.Id);
                     table.ForeignKey(
-                        name: "FK_GiftCardPayments_GiftCards_GiftCardId",
-                        column: x => x.GiftCardId,
-                        principalTable: "GiftCards",
+                        name: "FK_GiftcardPayments_Giftcards_GiftcardId",
+                        column: x => x.GiftcardId,
+                        principalTable: "Giftcards",
                         principalColumn: "Id",
                         onDelete: ReferentialAction.Restrict);
                 });
@@ -201,35 +201,6 @@ namespace OMGVA_PoS.Migrations
                     table.ForeignKey(
                         name: "FK_EmployeeSchedules_Users_EmployeeId",
                         column: x => x.EmployeeId,
-                        principalTable: "Users",
-                        principalColumn: "Id",
-                        onDelete: ReferentialAction.Restrict);
-                });
-
-            migrationBuilder.CreateTable(
-                name: "Orders",
-                columns: table => new
-                {
-                    Id = table.Column<long>(type: "bigint", nullable: false)
-                        .Annotation("SqlServer:Identity", "1, 1"),
-                    Status = table.Column<int>(type: "int", nullable: false),
-                    Tip = table.Column<decimal>(type: "decimal(18,2)", nullable: false),
-                    RefundReason = table.Column<string>(type: "nvarchar(max)", nullable: false),
-                    UserId = table.Column<long>(type: "bigint", nullable: false),
-                    DiscountId = table.Column<long>(type: "bigint", nullable: true)
-                },
-                constraints: table =>
-                {
-                    table.PrimaryKey("PK_Orders", x => x.Id);
-                    table.ForeignKey(
-                        name: "FK_Orders_Discounts_DiscountId",
-                        column: x => x.DiscountId,
-                        principalTable: "Discounts",
-                        principalColumn: "Id",
-                        onDelete: ReferentialAction.Restrict);
-                    table.ForeignKey(
-                        name: "FK_Orders_Users_UserId",
-                        column: x => x.UserId,
                         principalTable: "Users",
                         principalColumn: "Id",
                         onDelete: ReferentialAction.Restrict);
@@ -315,6 +286,68 @@ namespace OMGVA_PoS.Migrations
                 });
 
             migrationBuilder.CreateTable(
+                name: "Payments",
+                columns: table => new
+                {
+                    Id = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    Method = table.Column<int>(type: "int", nullable: false),
+                    CustomerId = table.Column<long>(type: "bigint", nullable: false),
+                    GiftCardPaymentId = table.Column<long>(type: "bigint", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Payments", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Payments_Customers_CustomerId",
+                        column: x => x.CustomerId,
+                        principalTable: "Customers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_Payments_GiftcardPayments_GiftCardPaymentId",
+                        column: x => x.GiftCardPaymentId,
+                        principalTable: "GiftcardPayments",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Orders",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Status = table.Column<int>(type: "int", nullable: false),
+                    Tip = table.Column<decimal>(type: "decimal(18,2)", nullable: false),
+                    RefundReason = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    PaymentId = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    UserId = table.Column<long>(type: "bigint", nullable: false),
+                    DiscountId = table.Column<long>(type: "bigint", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Orders", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Orders_Discounts_DiscountId",
+                        column: x => x.DiscountId,
+                        principalTable: "Discounts",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_Orders_Payments_PaymentId",
+                        column: x => x.PaymentId,
+                        principalTable: "Payments",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_Orders_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
                 name: "OrderItems",
                 columns: table => new
                 {
@@ -336,40 +369,6 @@ namespace OMGVA_PoS.Migrations
                         onDelete: ReferentialAction.Restrict);
                     table.ForeignKey(
                         name: "FK_OrderItems_Orders_OrderId",
-                        column: x => x.OrderId,
-                        principalTable: "Orders",
-                        principalColumn: "Id",
-                        onDelete: ReferentialAction.Restrict);
-                });
-
-            migrationBuilder.CreateTable(
-                name: "Payments",
-                columns: table => new
-                {
-                    Id = table.Column<long>(type: "bigint", nullable: false)
-                        .Annotation("SqlServer:Identity", "1, 1"),
-                    Method = table.Column<int>(type: "int", nullable: false),
-                    CustomerId = table.Column<long>(type: "bigint", nullable: false),
-                    GiftCardPaymentId = table.Column<long>(type: "bigint", nullable: true),
-                    OrderId = table.Column<long>(type: "bigint", nullable: false)
-                },
-                constraints: table =>
-                {
-                    table.PrimaryKey("PK_Payments", x => x.Id);
-                    table.ForeignKey(
-                        name: "FK_Payments_Customers_CustomerId",
-                        column: x => x.CustomerId,
-                        principalTable: "Customers",
-                        principalColumn: "Id",
-                        onDelete: ReferentialAction.Restrict);
-                    table.ForeignKey(
-                        name: "FK_Payments_GiftCardPayments_GiftCardPaymentId",
-                        column: x => x.GiftCardPaymentId,
-                        principalTable: "GiftCardPayments",
-                        principalColumn: "Id",
-                        onDelete: ReferentialAction.Restrict);
-                    table.ForeignKey(
-                        name: "FK_Payments_Orders_OrderId",
                         column: x => x.OrderId,
                         principalTable: "Orders",
                         principalColumn: "Id",
@@ -408,9 +407,9 @@ namespace OMGVA_PoS.Migrations
                 column: "EmployeeId");
 
             migrationBuilder.CreateIndex(
-                name: "IX_GiftCardPayments_GiftCardId",
-                table: "GiftCardPayments",
-                column: "GiftCardId");
+                name: "IX_GiftcardPayments_GiftcardId",
+                table: "GiftcardPayments",
+                column: "GiftcardId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_Items_BusinessId",
@@ -453,6 +452,12 @@ namespace OMGVA_PoS.Migrations
                 column: "DiscountId");
 
             migrationBuilder.CreateIndex(
+                name: "IX_Orders_PaymentId",
+                table: "Orders",
+                column: "PaymentId",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
                 name: "IX_Orders_UserId",
                 table: "Orders",
                 column: "UserId");
@@ -466,11 +471,6 @@ namespace OMGVA_PoS.Migrations
                 name: "IX_Payments_GiftCardPaymentId",
                 table: "Payments",
                 column: "GiftCardPaymentId");
-
-            migrationBuilder.CreateIndex(
-                name: "IX_Payments_OrderId",
-                table: "Payments",
-                column: "OrderId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_Reservations_CustomerId",
@@ -513,9 +513,6 @@ namespace OMGVA_PoS.Migrations
                 name: "OrderItemVariations");
 
             migrationBuilder.DropTable(
-                name: "Payments");
-
-            migrationBuilder.DropTable(
                 name: "Reservations");
 
             migrationBuilder.DropTable(
@@ -531,12 +528,6 @@ namespace OMGVA_PoS.Migrations
                 name: "OrderItems");
 
             migrationBuilder.DropTable(
-                name: "GiftCardPayments");
-
-            migrationBuilder.DropTable(
-                name: "Customers");
-
-            migrationBuilder.DropTable(
                 name: "Taxes");
 
             migrationBuilder.DropTable(
@@ -546,16 +537,25 @@ namespace OMGVA_PoS.Migrations
                 name: "Orders");
 
             migrationBuilder.DropTable(
-                name: "GiftCards");
+                name: "Discounts");
 
             migrationBuilder.DropTable(
-                name: "Discounts");
+                name: "Payments");
 
             migrationBuilder.DropTable(
                 name: "Users");
 
             migrationBuilder.DropTable(
+                name: "Customers");
+
+            migrationBuilder.DropTable(
+                name: "GiftcardPayments");
+
+            migrationBuilder.DropTable(
                 name: "Businesses");
+
+            migrationBuilder.DropTable(
+                name: "Giftcards");
         }
     }
 }

--- a/OMGVA PoS/Data layer/Migrations/OMGVADbContextModelSnapshot.cs
+++ b/OMGVA PoS/Data layer/Migrations/OMGVADbContextModelSnapshot.cs
@@ -8,7 +8,7 @@ using OMGVA_PoS.Data_layer.Context;
 
 #nullable disable
 
-namespace OMGVA_PoS.Migrations
+namespace OMGVA_PoS.Datalayer.Migrations
 {
     [DbContext(typeof(OMGVADbContext))]
     partial class OMGVADbContextModelSnapshot : ModelSnapshot
@@ -127,7 +127,7 @@ namespace OMGVA_PoS.Migrations
                     b.ToTable("EmployeeSchedules");
                 });
 
-            modelBuilder.Entity("OMGVA_PoS.Data_layer.Models.GiftCard", b =>
+            modelBuilder.Entity("OMGVA_PoS.Data_layer.Models.Giftcard", b =>
                 {
                     b.Property<long>("Id")
                         .ValueGeneratedOnAdd()
@@ -143,10 +143,10 @@ namespace OMGVA_PoS.Migrations
 
                     b.HasKey("Id");
 
-                    b.ToTable("GiftCards");
+                    b.ToTable("Giftcards");
                 });
 
-            modelBuilder.Entity("OMGVA_PoS.Data_layer.Models.GiftCardPayment", b =>
+            modelBuilder.Entity("OMGVA_PoS.Data_layer.Models.GiftcardPayment", b =>
                 {
                     b.Property<long>("Id")
                         .ValueGeneratedOnAdd()
@@ -157,14 +157,14 @@ namespace OMGVA_PoS.Migrations
                     b.Property<decimal>("AmountUsed")
                         .HasColumnType("decimal(18,2)");
 
-                    b.Property<long>("GiftCardId")
+                    b.Property<long>("GiftcardId")
                         .HasColumnType("bigint");
 
                     b.HasKey("Id");
 
-                    b.HasIndex("GiftCardId");
+                    b.HasIndex("GiftcardId");
 
-                    b.ToTable("GiftCardPayments");
+                    b.ToTable("GiftcardPayments");
                 });
 
             modelBuilder.Entity("OMGVA_PoS.Data_layer.Models.Item", b =>
@@ -264,6 +264,10 @@ namespace OMGVA_PoS.Migrations
                     b.Property<long?>("DiscountId")
                         .HasColumnType("bigint");
 
+                    b.Property<string>("PaymentId")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(450)");
+
                     b.Property<string>("RefundReason")
                         .IsRequired()
                         .HasColumnType("nvarchar(max)");
@@ -280,6 +284,9 @@ namespace OMGVA_PoS.Migrations
                     b.HasKey("Id");
 
                     b.HasIndex("DiscountId");
+
+                    b.HasIndex("PaymentId")
+                        .IsUnique();
 
                     b.HasIndex("UserId");
 
@@ -340,11 +347,8 @@ namespace OMGVA_PoS.Migrations
 
             modelBuilder.Entity("OMGVA_PoS.Data_layer.Models.Payment", b =>
                 {
-                    b.Property<long>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("bigint");
-
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
+                    b.Property<string>("Id")
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<long>("CustomerId")
                         .HasColumnType("bigint");
@@ -355,16 +359,11 @@ namespace OMGVA_PoS.Migrations
                     b.Property<int>("Method")
                         .HasColumnType("int");
 
-                    b.Property<long>("OrderId")
-                        .HasColumnType("bigint");
-
                     b.HasKey("Id");
 
                     b.HasIndex("CustomerId");
 
                     b.HasIndex("GiftCardPaymentId");
-
-                    b.HasIndex("OrderId");
 
                     b.ToTable("Payments");
                 });
@@ -513,15 +512,15 @@ namespace OMGVA_PoS.Migrations
                     b.Navigation("User");
                 });
 
-            modelBuilder.Entity("OMGVA_PoS.Data_layer.Models.GiftCardPayment", b =>
+            modelBuilder.Entity("OMGVA_PoS.Data_layer.Models.GiftcardPayment", b =>
                 {
-                    b.HasOne("OMGVA_PoS.Data_layer.Models.GiftCard", "GiftCard")
-                        .WithMany("GiftCardPayments")
-                        .HasForeignKey("GiftCardId")
+                    b.HasOne("OMGVA_PoS.Data_layer.Models.Giftcard", "Giftcard")
+                        .WithMany("GiftcardPayments")
+                        .HasForeignKey("GiftcardId")
                         .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
-                    b.Navigation("GiftCard");
+                    b.Navigation("Giftcard");
                 });
 
             modelBuilder.Entity("OMGVA_PoS.Data_layer.Models.Item", b =>
@@ -560,6 +559,12 @@ namespace OMGVA_PoS.Migrations
                         .HasForeignKey("DiscountId")
                         .OnDelete(DeleteBehavior.Restrict);
 
+                    b.HasOne("OMGVA_PoS.Data_layer.Models.Payment", "Payment")
+                        .WithOne("Order")
+                        .HasForeignKey("OMGVA_PoS.Data_layer.Models.Order", "PaymentId")
+                        .OnDelete(DeleteBehavior.Restrict)
+                        .IsRequired();
+
                     b.HasOne("OMGVA_PoS.Data_layer.Models.User", "User")
                         .WithMany("Orders")
                         .HasForeignKey("UserId")
@@ -567,6 +572,8 @@ namespace OMGVA_PoS.Migrations
                         .IsRequired();
 
                     b.Navigation("Discount");
+
+                    b.Navigation("Payment");
 
                     b.Navigation("User");
                 });
@@ -616,22 +623,14 @@ namespace OMGVA_PoS.Migrations
                         .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
-                    b.HasOne("OMGVA_PoS.Data_layer.Models.GiftCardPayment", "GiftCardPayment")
+                    b.HasOne("OMGVA_PoS.Data_layer.Models.GiftcardPayment", "GiftcardPayment")
                         .WithMany()
                         .HasForeignKey("GiftCardPaymentId")
                         .OnDelete(DeleteBehavior.Restrict);
 
-                    b.HasOne("OMGVA_PoS.Data_layer.Models.Order", "Order")
-                        .WithMany("Payments")
-                        .HasForeignKey("OrderId")
-                        .OnDelete(DeleteBehavior.Restrict)
-                        .IsRequired();
-
                     b.Navigation("Customer");
 
-                    b.Navigation("GiftCardPayment");
-
-                    b.Navigation("Order");
+                    b.Navigation("GiftcardPayment");
                 });
 
             modelBuilder.Entity("OMGVA_PoS.Data_layer.Models.Reservation", b =>
@@ -718,9 +717,9 @@ namespace OMGVA_PoS.Migrations
                     b.Navigation("Orders");
                 });
 
-            modelBuilder.Entity("OMGVA_PoS.Data_layer.Models.GiftCard", b =>
+            modelBuilder.Entity("OMGVA_PoS.Data_layer.Models.Giftcard", b =>
                 {
-                    b.Navigation("GiftCardPayments");
+                    b.Navigation("GiftcardPayments");
                 });
 
             modelBuilder.Entity("OMGVA_PoS.Data_layer.Models.Item", b =>
@@ -738,13 +737,17 @@ namespace OMGVA_PoS.Migrations
             modelBuilder.Entity("OMGVA_PoS.Data_layer.Models.Order", b =>
                 {
                     b.Navigation("OrderItems");
-
-                    b.Navigation("Payments");
                 });
 
             modelBuilder.Entity("OMGVA_PoS.Data_layer.Models.OrderItem", b =>
                 {
                     b.Navigation("OrderItemVariations");
+                });
+
+            modelBuilder.Entity("OMGVA_PoS.Data_layer.Models.Payment", b =>
+                {
+                    b.Navigation("Order")
+                        .IsRequired();
                 });
 
             modelBuilder.Entity("OMGVA_PoS.Data_layer.Models.Tax", b =>

--- a/OMGVA PoS/Data layer/Models/Giftcard.cs
+++ b/OMGVA PoS/Data layer/Models/Giftcard.cs
@@ -1,12 +1,12 @@
 ﻿namespace OMGVA_PoS.Data_layer.Models
 {
-    public class GiftCard
+    public class Giftcard
     {
         public long Id { get; set; }
         public decimal Value { get; set; }
         public decimal Balance { get; set; }
 
         // navigation properties
-        public ICollection<GiftCardPayment> GiftCardPayments { get; set; } // GiftCard can be paid with
+        public ICollection<GiftcardPayment> GiftcardPayments { get; set; } // Giftcard can be paid with
     }
 }

--- a/OMGVA PoS/Data layer/Models/GiftcardPayment.cs
+++ b/OMGVA PoS/Data layer/Models/GiftcardPayment.cs
@@ -1,13 +1,13 @@
 ﻿namespace OMGVA_PoS.Data_layer.Models
 {
-    public class GiftCardPayment
+    public class GiftcardPayment
     {
         public long Id { get; set; }
-        public long GiftCardId { get; set; }
+        public long GiftcardId { get; set; }
         public decimal AmountUsed { get; set; }
 
         // navigation properties
         // for foreign keys
-        public GiftCard GiftCard { get; set; }
+        public Giftcard Giftcard { get; set; }
     }
 }

--- a/OMGVA PoS/Data layer/Models/Order.cs
+++ b/OMGVA PoS/Data layer/Models/Order.cs
@@ -8,13 +8,15 @@ namespace OMGVA_PoS.Data_layer.Models
         public OrderStatus Status { get; set; }
         public decimal Tip { get; set; }
         public string RefundReason { get; set; }
+        public string PaymentId { get; set; }
         public long UserId { get; set; }
         public long? DiscountId { get; set; }
 
         // navigational properties
         public ICollection<OrderItem> OrderItems { get; set; }  // Order can have (order)items 
-        public ICollection<Payment> Payments { get; set; } // order can have multiple / split payments
+
         // for foreign keys
+        public Payment Payment { get; set; }    
         public Discount Discount { get; set; }
         public User User {  get; set; }
     }

--- a/OMGVA PoS/Data layer/Models/Payment.cs
+++ b/OMGVA PoS/Data layer/Models/Payment.cs
@@ -4,15 +4,14 @@ namespace OMGVA_PoS.Data_layer.Models
 {
     public class Payment
     {
-        public long Id { get; set; }
+        public string Id { get; set; }
         public PaymentMethod Method { get; set; }
         public long CustomerId { get; set; }
         public long? GiftCardPaymentId { get; set; }
-        public long OrderId { get; set; }
         
         // navigational properties
         // for foreign keys
-        public GiftCardPayment GiftCardPayment { get; set; }
+        public GiftcardPayment GiftcardPayment { get; set; }
         public Customer Customer { get; set; }
         public Order Order { get; set; }
 

--- a/OMGVA PoS/Helper modules/Utilities/Enums.cs
+++ b/OMGVA PoS/Helper modules/Utilities/Enums.cs
@@ -21,7 +21,7 @@
     public enum PaymentMethod {
         Cash,
         Card,
-        GiftCard
+        Giftcard
     }
 
     public enum ReservationStatus {

--- a/OMGVA PoS/OMGVA PoS.csproj
+++ b/OMGVA PoS/OMGVA PoS.csproj
@@ -26,6 +26,7 @@
 
   <ItemGroup>
     <Folder Include="Business layer\Services\" />
+    <Folder Include="Data layer\Migrations\" />
   </ItemGroup>
 
 </Project>

--- a/OMGVA PoS/appsettings.json
+++ b/OMGVA PoS/appsettings.json
@@ -7,7 +7,7 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "LocalDatabase": "Server=(localdb)\\MSSQLLocalDB;Database=OMGVAPOS;Trusted_Connection=True;"
+    "LocalDatabase": "Server=DESKTOP-3IVF1HD\\OMGVADB;Database=OMGVADB;Trusted_Connection=True;TrustServerCertificate=True"
   },
 
   "UseCloudDatabase": false


### PR DESCRIPTION
- reverted naming of stuff like GiftCard->Giftcard to as it was in my last merge
- reverted payment and order relations to as they were in my last merge (split orders for split payments)
- squashed migrations

What to do:
1. Delete all tables from local db: 
1.1. Either through executing the script in SSMS (script in discord) 
1.2. or do it manually.
2. Update-Database