### PR TITLE
[db-initialization-improvements] add fake data for businesses, users and tax

### DIFF
--- a/OmgvaPOS/Program.cs
+++ b/OmgvaPOS/Program.cs
@@ -116,7 +116,7 @@ if (app.Environment.IsDevelopment())
         var dbContext = scope.ServiceProvider.GetRequiredService<OmgvaDbContext>();
         var logger = scope.ServiceProvider.GetRequiredService<ILogger<DbInitializer>>();
         var dbInitializer = new DbInitializer(dbContext, logger);
-        await dbInitializer.InitDb(initDatabaseAction);
+        dbInitializer.InitDb(initDatabaseAction);
         logger.LogInformation($"Exiting after completing database action {initDatabaseAction}...");
         return;
     }

--- a/OmgvaPOS/Program.cs
+++ b/OmgvaPOS/Program.cs
@@ -10,7 +10,7 @@ using OmgvaPOS.TaxManagement.Repository;
 using OmgvaPOS.UserManagement.Repository;
 
 var builder = WebApplication.CreateBuilder(args);
-var initDatabaseAction = DbInitializerAction.DO_NOTHING;
+var initDatabaseAction = DbInitializerAction.DoNothing;
 
 // Add services to the container.
 
@@ -110,11 +110,16 @@ if (app.Environment.IsDevelopment())
     app.UseSwagger();
     app.UseSwaggerUI();
 
-    using var scope = app.Services.CreateScope();
-    var dbContext = scope.ServiceProvider.GetRequiredService<OmgvaDbContext>();
-    var logger = scope.ServiceProvider.GetRequiredService<ILogger<DbInitializer>>();
-    var dbInitializer = new DbInitializer(dbContext, logger);
-    await dbInitializer.InitDb(initDatabaseAction);
+    if (initDatabaseAction != DbInitializerAction.DoNothing)
+    {
+        using var scope = app.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<OmgvaDbContext>();
+        var logger = scope.ServiceProvider.GetRequiredService<ILogger<DbInitializer>>();
+        var dbInitializer = new DbInitializer(dbContext, logger);
+        await dbInitializer.InitDb(initDatabaseAction);
+        logger.LogInformation($"Exiting after completing database action {initDatabaseAction}...");
+        return;
+    }
 }
 
 app.UseHttpsRedirection();

--- a/OmgvaPOS/src/Database/Context/DbInitializer.cs
+++ b/OmgvaPOS/src/Database/Context/DbInitializer.cs
@@ -13,22 +13,29 @@ public class DbInitializer
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
-    public async Task InitDb(DbInitializerAction dbInitializerAction)
+    public void InitDb(DbInitializerAction dbInitializerAction)
     {
         _logger.LogInformation("Initializing database with action: {Action}", dbInitializerAction);
 
         try
         {
-            Task actionTask = dbInitializerAction switch
+            switch (dbInitializerAction)
             {
-                DbInitializerAction.DoNothing => Task.CompletedTask,
-                DbInitializerAction.ResetDatabaseData => ResetDatabaseDataAsync(),
-                DbInitializerAction.RemoveAllData => RemoveAllDataAsync(),
-                DbInitializerAction.SeedMockData => InitializeMockDataAsync(),
-                _ => throw new ArgumentException("Invalid DbInitializerAction", nameof(dbInitializerAction))
-            };
+                case DbInitializerAction.DoNothing:
+                    break;
+                case DbInitializerAction.ResetDatabaseData:
+                    ResetDatabaseData();
+                    break;
+                case DbInitializerAction.RemoveAllData:
+                    RemoveAllData();
+                    break;
+                case DbInitializerAction.SeedMockData:
+                    InitializeMockData();
+                    break;
+                default:
+                    throw new ArgumentException("Invalid DbInitializerAction", nameof(dbInitializerAction));
+            }
 
-            await actionTask;
             _logger.LogInformation("Database initialization completed successfully.");
         }
         catch (Exception ex)
@@ -38,29 +45,29 @@ public class DbInitializer
         }
     }
 
-    private async Task ResetDatabaseDataAsync()
+    private void ResetDatabaseData()
     {
         _logger.LogInformation("Resetting database data...");
-        await RemoveAllDataAsync();
-        await InitializeMockDataAsync();
+        RemoveAllData();
+        InitializeMockData();
         _logger.LogInformation("Resetting database data complete...");
     }
 
-    private async Task InitializeMockDataAsync()
+    private void InitializeMockData()
     {
         _logger.LogInformation("Initializing mock data...");
-        await MockBusinessesDataHelper.InitializeMockBusinessesAsync(_context, _logger);
-        await MockUserDataHelper.InitializeMockUsersAsync(_context, _logger);
-        await MockTaxesDataHelper.InitializeMockTaxesAsync(_context, _logger);
+        MockBusinessesDataHelper.InitializeMockBusinesses(_context, _logger);
+        MockUserDataHelper.InitializeMockUsers(_context, _logger);
+        MockTaxesDataHelper.InitializeMockTaxes(_context, _logger);
         _logger.LogInformation("Mock data initialized");
     }
 
-    private async Task RemoveAllDataAsync()
+    private void RemoveAllData()
     {
         _logger.LogInformation("Removing all data from the database...");
-        await MockUserDataHelper.RemoveAllUsersAsync(_context, _logger);
-        await MockTaxesDataHelper.RemoveAllTaxAsync(_context, _logger);
-        await MockBusinessesDataHelper.RemoveAllBusinessesAsync(_context, _logger);
+        MockUserDataHelper.RemoveAllUsers(_context, _logger);
+        MockTaxesDataHelper.RemoveAllTax(_context, _logger);
+        MockBusinessesDataHelper.RemoveAllBusinesses(_context, _logger);
         _logger.LogInformation("All data removed");
     }
 

--- a/OmgvaPOS/src/Database/Context/DbInitializerAction.cs
+++ b/OmgvaPOS/src/Database/Context/DbInitializerAction.cs
@@ -2,8 +2,8 @@
 
 public enum DbInitializerAction
 {
-    DO_NOTHING,
-    RESET_DATABASE,
-    REMOVE_ALL_DATA,
-    INITIALIZE_MOCK_DATA
+    DoNothing,
+    ResetDatabaseData,
+    RemoveAllData,
+    SeedMockData
 }

--- a/OmgvaPOS/src/Database/Context/MockDataHelpers/MockBusinessesDataHelper.cs
+++ b/OmgvaPOS/src/Database/Context/MockDataHelpers/MockBusinessesDataHelper.cs
@@ -8,7 +8,7 @@ public static class MockBusinessesDataHelper
     public static long OmgvaBusinessId = 0;
     public static long DiffBusinessId = 0;
     
-    public static async Task InitializeMockBusinessesAsync(OmgvaDbContext dbContext, ILogger logger)
+    public static void InitializeMockBusinesses(OmgvaDbContext dbContext, ILogger logger)
     {
         logger.LogDebug("Adding mock businesses...");
         var omgvaBusiness = new Business
@@ -27,21 +27,21 @@ public static class MockBusinessesDataHelper
             Phone = "987654321",
             Email = "info@diffbusiness.com"
         };
-        await dbContext.Businesses.AddAsync(omgvaBusiness);
-        await dbContext.Businesses.AddAsync(diffBusiness);
-        await dbContext.SaveChangesAsync();
+        dbContext.Businesses.Add(omgvaBusiness);
+        dbContext.Businesses.Add(diffBusiness);
+        dbContext.SaveChanges();
         
         OmgvaBusinessId = omgvaBusiness.Id;
         DiffBusinessId = diffBusiness.Id;
         logger.LogDebug("Mock businesses added.");
     }
     
-    public static async Task RemoveAllBusinessesAsync(OmgvaDbContext dbContext, ILogger logger)
+    public static void RemoveAllBusinesses(OmgvaDbContext dbContext, ILogger logger)
     {
         logger.LogDebug("Removing all businesses...");
-        var allBusinesses = await dbContext.Businesses.ToListAsync();
+        var allBusinesses = dbContext.Businesses.ToList();
         dbContext.Businesses.RemoveRange(allBusinesses);
-        await dbContext.SaveChangesAsync();
+        dbContext.SaveChanges();
         logger.LogDebug("All businesses removed.");
     }
 

--- a/OmgvaPOS/src/Database/Context/MockDataHelpers/MockBusinessesDataHelper.cs
+++ b/OmgvaPOS/src/Database/Context/MockDataHelpers/MockBusinessesDataHelper.cs
@@ -1,0 +1,48 @@
+using Microsoft.EntityFrameworkCore;
+using OmgvaPOS.BusinessManagement.Models;
+
+namespace OmgvaPOS.Database.Context.MockDataHelpers;
+
+public static class MockBusinessesDataHelper
+{
+    public static long OmgvaBusinessId = 0;
+    public static long DiffBusinessId = 0;
+    
+    public static async Task InitializeMockBusinessesAsync(OmgvaDbContext dbContext, ILogger logger)
+    {
+        logger.LogDebug("Adding mock businesses...");
+        var omgvaBusiness = new Business
+        {
+            StripeAccId = "null_stripe_acc_id",
+            Name = "Omgva Business",
+            Address = "Address 1",
+            Phone = "123456789",
+            Email = "info@omgva.com"
+        };
+        var diffBusiness = new Business
+        {
+            StripeAccId = "null_stripe_acc_id",
+            Name = "Diff Business",
+            Address = "Address 2",
+            Phone = "987654321",
+            Email = "info@diffbusiness.com"
+        };
+        await dbContext.Businesses.AddAsync(omgvaBusiness);
+        await dbContext.Businesses.AddAsync(diffBusiness);
+        await dbContext.SaveChangesAsync();
+        
+        OmgvaBusinessId = omgvaBusiness.Id;
+        DiffBusinessId = diffBusiness.Id;
+        logger.LogDebug("Mock businesses added.");
+    }
+    
+    public static async Task RemoveAllBusinessesAsync(OmgvaDbContext dbContext, ILogger logger)
+    {
+        logger.LogDebug("Removing all businesses...");
+        var allBusinesses = await dbContext.Businesses.ToListAsync();
+        dbContext.Businesses.RemoveRange(allBusinesses);
+        await dbContext.SaveChangesAsync();
+        logger.LogDebug("All businesses removed.");
+    }
+
+}

--- a/OmgvaPOS/src/Database/Context/MockDataHelpers/MockTaxesDataHelper.cs
+++ b/OmgvaPOS/src/Database/Context/MockDataHelpers/MockTaxesDataHelper.cs
@@ -6,20 +6,20 @@ namespace OmgvaPOS.Database.Context.MockDataHelpers;
 public static class MockTaxesDataHelper
 {
     
-    public static async Task InitializeMockTaxesAsync(OmgvaDbContext dbContext, ILogger logger)
+    public static void InitializeMockTaxes(OmgvaDbContext dbContext, ILogger logger)
     {
         logger.LogDebug("Adding mock taxes...");
-        await dbContext.Taxes.AddRangeAsync(MockTaxes());
-        await dbContext.SaveChangesAsync();
+        dbContext.Taxes.AddRange(MockTaxes());
+        dbContext.SaveChanges();
         logger.LogDebug("Mock taxes added.");
     }
     
-    public static async Task RemoveAllTaxAsync(OmgvaDbContext dbContext, ILogger logger)
+    public static void RemoveAllTax(OmgvaDbContext dbContext, ILogger logger)
     {
         logger.LogDebug("Removing all taxes...");
-        var allTaxes = await dbContext.Taxes.ToListAsync();
+        var allTaxes = dbContext.Taxes.ToList();
         dbContext.Taxes.RemoveRange(allTaxes);
-        await dbContext.SaveChangesAsync();
+        dbContext.SaveChanges();
         logger.LogDebug("All taxes removed.");
     }
 

--- a/OmgvaPOS/src/Database/Context/MockDataHelpers/MockTaxesDataHelper.cs
+++ b/OmgvaPOS/src/Database/Context/MockDataHelpers/MockTaxesDataHelper.cs
@@ -1,0 +1,35 @@
+using Microsoft.EntityFrameworkCore;
+using OmgvaPOS.TaxManagement.Models;
+
+namespace OmgvaPOS.Database.Context.MockDataHelpers;
+
+public static class MockTaxesDataHelper
+{
+    
+    public static async Task InitializeMockTaxesAsync(OmgvaDbContext dbContext, ILogger logger)
+    {
+        logger.LogDebug("Adding mock taxes...");
+        await dbContext.Taxes.AddRangeAsync(MockTaxes());
+        await dbContext.SaveChangesAsync();
+        logger.LogDebug("Mock taxes added.");
+    }
+    
+    public static async Task RemoveAllTaxAsync(OmgvaDbContext dbContext, ILogger logger)
+    {
+        logger.LogDebug("Removing all taxes...");
+        var allTaxes = await dbContext.Taxes.ToListAsync();
+        dbContext.Taxes.RemoveRange(allTaxes);
+        await dbContext.SaveChangesAsync();
+        logger.LogDebug("All taxes removed.");
+    }
+
+    private static IEnumerable<Tax> MockTaxes()
+    {
+        return new List<Tax>
+        {
+            new() { TaxType = "VAT", Percent = 20, IsArchived = false },
+            new() { TaxType = "Service Tax", Percent = 5, IsArchived = false },
+            new() { TaxType = "Sales Tax", Percent = 10, IsArchived = true }
+        };
+    }
+}

--- a/OmgvaPOS/src/Database/Context/MockDataHelpers/MockUserDataHelper.cs
+++ b/OmgvaPOS/src/Database/Context/MockDataHelpers/MockUserDataHelper.cs
@@ -1,0 +1,77 @@
+using Microsoft.EntityFrameworkCore;
+using OmgvaPOS.UserManagement.Enums;
+using OmgvaPOS.UserManagement.Models;
+
+namespace OmgvaPOS.Database.Context.MockDataHelpers;
+
+public static class MockUserDataHelper
+{
+
+    public static async Task InitializeMockUsersAsync(OmgvaDbContext dbContext, ILogger logger)
+    {
+        logger.LogDebug("Adding mock users...");
+        await dbContext.Users.AddRangeAsync(MockUsers());
+        await dbContext.SaveChangesAsync();
+        logger.LogDebug("Mock users added.");
+    }
+    
+    public static async Task RemoveAllUsersAsync(OmgvaDbContext dbContext, ILogger logger)
+    {
+        logger.LogDebug("Removing all users...");
+        var allUsers = await dbContext.Users.ToListAsync();
+        dbContext.Users.RemoveRange(allUsers);
+        await dbContext.SaveChangesAsync();
+        logger.LogDebug("All users removed.");
+    }
+
+    private static IEnumerable<User> MockUsers()
+    {
+        return new List<User>
+        {
+            // Users for OMGVA
+            MockUser("Owner Omgva", "ownerOmgva", "owner@omgva.com",
+                     UserRole.Owner, "ownerPass", MockBusinessesDataHelper.OmgvaBusinessId),
+            MockUser("Admin Omgva", "adminOmgva", "admin@omgva.com",
+                     UserRole.Admin, "adminPass", MockBusinessesDataHelper.OmgvaBusinessId),
+            MockUser("Employee Omgva", "employeeOmgva", "employee@omgva.com",
+                     UserRole.Employee, "employeePass", MockBusinessesDataHelper.OmgvaBusinessId),
+
+            // Users for Different business
+            MockUser("Owner DiffBusiness", "ownerDiffBusiness", "owner@diffbusiness.com",
+                UserRole.Owner, "ownerPass", MockBusinessesDataHelper.DiffBusinessId),
+            MockUser("Admin DiffBusiness", "adminDiffBusiness", "admin@diffbusiness.com",
+                UserRole.Admin, "adminPass", MockBusinessesDataHelper.DiffBusinessId),
+            MockUser("Employee DiffBusiness", "adminDiffBusiness", "employee@diffbusiness.com",
+                UserRole.Employee, "employeePass", MockBusinessesDataHelper.DiffBusinessId),
+            
+            // Users without a business
+            MockUser("Owner NoBusiness", "ownerNoBusiness", "owner@nobusiness.com",
+                     UserRole.Owner, "ownerPass"),
+            MockUser("Admin NoBusiness", "adminNoBusiness", "admin@nobusiness.com",
+                     UserRole.Admin, "adminPass"),
+            MockUser("Employee NoBusiness", "adminNoBusiness", "employee@nobusiness.com",
+                     UserRole.Employee, "employeePass")
+        };
+    }
+
+    private static User MockUser(
+        string name,
+        string username,
+        string email,
+        UserRole role,
+        string password,
+        long? businessId = null,
+        bool hasLeft = false)
+    {
+        return new User
+        {
+            BusinessId = businessId,
+            Name = name,
+            Username = username,
+            Email = email,
+            Role = role,
+            Password = BCrypt.Net.BCrypt.EnhancedHashPassword(password, 13),
+            HasLeft = hasLeft
+        };
+    }
+}

--- a/OmgvaPOS/src/Database/Context/MockDataHelpers/MockUserDataHelper.cs
+++ b/OmgvaPOS/src/Database/Context/MockDataHelpers/MockUserDataHelper.cs
@@ -7,20 +7,20 @@ namespace OmgvaPOS.Database.Context.MockDataHelpers;
 public static class MockUserDataHelper
 {
 
-    public static async Task InitializeMockUsersAsync(OmgvaDbContext dbContext, ILogger logger)
+    public static void InitializeMockUsers(OmgvaDbContext dbContext, ILogger logger)
     {
         logger.LogDebug("Adding mock users...");
-        await dbContext.Users.AddRangeAsync(MockUsers());
-        await dbContext.SaveChangesAsync();
+        dbContext.Users.AddRange(MockUsers());
+        dbContext.SaveChanges();
         logger.LogDebug("Mock users added.");
     }
     
-    public static async Task RemoveAllUsersAsync(OmgvaDbContext dbContext, ILogger logger)
+    public static void RemoveAllUsers(OmgvaDbContext dbContext, ILogger logger)
     {
         logger.LogDebug("Removing all users...");
-        var allUsers = await dbContext.Users.ToListAsync();
+        var allUsers = dbContext.Users.ToList();
         dbContext.Users.RemoveRange(allUsers);
-        await dbContext.SaveChangesAsync();
+        dbContext.SaveChanges();
         logger.LogDebug("All users removed.");
     }
 


### PR DESCRIPTION
In order for us to have similar fake data to have reproducible results added more fake data  
Now we have 2 businesses, 3 users for one business, 3 for another and 3 without a business
Passwords and usernames for them are setup in MockUserDataHelper
To use the mock data, set initDatabaseAction in _Program.cs_ to ResetDatabaseData
![image](https://github.com/user-attachments/assets/3c29f574-9f60-4452-a23c-08d65fd0e0fc)

![image](https://github.com/user-attachments/assets/1f15eb74-146a-4f9a-b274-945bf7f6621c)
![image](https://github.com/user-attachments/assets/4696f975-3b16-4e54-a196-459652507780)
![image](https://github.com/user-attachments/assets/d343e949-8227-48fe-892e-7ff6cc2eb23d)
![image](https://github.com/user-attachments/assets/e60592f2-d11a-4056-a89b-e544cf0807f9)

